### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ previous iterations are in [assets/screenshot](https://github.com/71zenith/asset
 wallpapers are in [assets/active](https://github.com/71zenith/assets/tree/master/active).
 
 ## Nix components
-- [flakes](https://nixos.wiki/wiki/Flakes) - channel manager
+- [flakes](https://wiki.nixos.org/wiki/Flakes) - channel manager
 - [home-manager](https://github.com/nix-community/home-manager) - manage dots
 - [stylix](https://github.com/danth/stylix) - auto themer
 - [nix-colors](https://github.com/Misterio77/nix-colors) - base 16 scheme

--- a/hosts/izanagi/hm/hyprland.nix
+++ b/hosts/izanagi/hm/hyprland.nix
@@ -90,9 +90,11 @@ in {
         preserve_split = true;
       };
       misc = {
+        font_family = config.stylix.fonts.serif.name;
         enable_swallow = true;
         force_default_wallpaper = 0;
         new_window_takes_over_fullscreen = 1;
+        disable_splash_rendering = true;
         disable_hyprland_logo = true;
         swallow_regex = "^(foot).*$";
       };
@@ -101,8 +103,9 @@ in {
         drop_shadow = true;
         shadow_range = 10;
         dim_inactive = true;
-        dim_strength = 0.15;
+        dim_strength = 0.1618;
       };
+      binds.workspace_back_and_forth = true;
       general = {
         gaps_in = 6;
         gaps_out = 8;
@@ -116,9 +119,6 @@ in {
       };
       cursor = {
         no_hardware_cursors = true;
-      };
-      debug = {
-        disable_logs = false;
       };
       animations = {
         enabled = true;


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️